### PR TITLE
add CrystalBombExploderCollider + ModInterop export

### DIFF
--- a/Code/CavernInterop.cs
+++ b/Code/CavernInterop.cs
@@ -16,5 +16,11 @@ namespace Celeste.Mod.CavernHelper {
         public static Component GetCrystalBombExplosionCollider(Action<Vector2> action, Collider collider = null) {
             return new CrystalBombExplosionCollider(action, collider);
         }
+
+        // Creates and returns a CrystalBombExploderCollider as a Component.
+        //   Collider collider: the collider to use for the check. Defaults to the entity collider.
+        public static Component GetCrystalBombExploderCollider(Collider collider = null) {
+            return new CrystalBombExploderCollider(collider);
+        }
     }
 }

--- a/Code/CrystalBomb.cs
+++ b/Code/CrystalBomb.cs
@@ -109,6 +109,13 @@ namespace Celeste.Mod.CavernHelper {
                     field.Collidable = false;
                 }
 
+                foreach (CrystalBombExploderCollider collider in Scene.Tracker.GetComponents<CrystalBombExploderCollider>()) {
+                    if (collider.Check(this)) {
+                        Explode();
+                        return;
+                    }
+                }
+
                 if (!Hold.IsHeld) {
                     if (legacyMode) {
                         foreach (Spring spring in Scene.Entities.OfType<Spring>()) {

--- a/Code/CrystalBombExploderCollider.cs
+++ b/Code/CrystalBombExploderCollider.cs
@@ -1,0 +1,34 @@
+﻿using Microsoft.Xna.Framework;
+using Monocle;
+using System;
+using System.Collections.Generic;
+
+namespace Celeste.Mod.CavernHelper {
+    [Tracked]
+    // Component that makes Crystal Bombs explode when they touch the collider.
+    public class CrystalBombExploderCollider : Component {
+        public Collider Collider;
+
+        public CrystalBombExploderCollider(Collider collider = null)
+            : base(false, false) {
+            Collider = collider;
+        }
+
+        internal bool Check(CrystalBomb bomb) {
+            Collider origCollider = Entity.Collider;
+            if (Collider != null) {
+                Entity.Collider = Collider;
+            }
+
+            bool result = false;
+
+            if (bomb.CollideCheck(Entity)) {
+                result = true;
+            }
+
+            Entity.Collider = origCollider;
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
This adds a component similar to `CrystalBombExplosionCollider`, but instead of reacting to explosions, it'll instead cause intact Crystal Bombs to explode on collision. It also adds a ModInterop export for the component.

The reason for this is that I'm porting the custom Badeline Boss from Attack of the Clone in SJ, which will detonate Crystal Bombs on collision. In SJ this is simpler because that has a hard dependency on Cavern Helper anyway, but for a standalone helper it's much nicer to have ModInterop support for this, especially since there already is one for reacting to explosions.

(I wonder if it should have a better name than `CrystalBombExploderCollider` though? It's a bit confusingly similar to the existing `CrystalBombExplosionCollider`, but I also can't think of a better name for it. Definitely open to changes here.)