### PR TITLE
Fix CrystalBombFields drawing at high resolution in Motion Smoothing's Fancy mode

### DIFF
--- a/Code/CrystalBombFieldRenderer.cs
+++ b/Code/CrystalBombFieldRenderer.cs
@@ -141,7 +141,7 @@ namespace Celeste.Mod.CavernHelper {
                     Vector2 vector = edge.Parent.Position + edge.B;
                     for (int num = 0; num <= edge.Length; num++) {
                         Vector2 vector2 = value + (edge.Normal * num);
-                        Draw.Line(vector2, vector2 + (edge.Perpendicular * edge.Wave[num]), Color.Purple);
+                        Draw.Line(vector2, Calc.Round(vector2 + (edge.Perpendicular * edge.Wave[num])), Color.Purple);
                     }
                 }
             }


### PR DESCRIPTION
One-line fix that doesn't affect anything unless Motion Smoothing is loaded and in Fancy mode